### PR TITLE
Adds an Application::data() alias 

### DIFF
--- a/src/Domain/Application.php
+++ b/src/Domain/Application.php
@@ -18,7 +18,7 @@ class Application
             data: BalanceRequest::build()->asForm()->fetch()
         );
     }
-    
+
     /**
      * @throws RequestException
      */

--- a/src/Domain/Application.php
+++ b/src/Domain/Application.php
@@ -18,4 +18,12 @@ class Application
             data: BalanceRequest::build()->asForm()->fetch()
         );
     }
+    
+    /**
+     * @throws RequestException
+     */
+    public function data(): Balance
+    {
+        return $this->balance();
+    }
 }


### PR DESCRIPTION
Adds an `Application::data()` alias to `Application::balance()` to align closely with the documentation.

All these examples below do the exact same thing. Boils down to preference.

```php
africastalking()->app()->data();
africastalking()->app()->balance();

africastalking()->application()->data();
africastalking()->application()->balance();
```