### PR TITLE
Added token as alias for send

### DIFF
--- a/src/Domain/WebRTCToken.php
+++ b/src/Domain/WebRTCToken.php
@@ -50,6 +50,17 @@ class WebRTCToken
             ->dto();
     }
 
+    /**
+     * @throws \ReflectionException
+     * @throws GuzzleException
+     * @throws SaloonException
+     * @throws SaloonRequestException
+     */
+    public function token(): CapabilityToken
+    {
+        return $this->send();
+    }
+
     public function clientName(): string
     {
         return $this->clientName ?? Str::random();

--- a/tests/VoiceTest.php
+++ b/tests/VoiceTest.php
@@ -125,3 +125,28 @@ it('requests a webrtc capability token', function () {
         ->lifeTimeSec->toBe('86400')
         ->token->toBe('ATCAPtkn_somerandomtexthere');
 });
+it('WebRTC token has a token alias for send', function () {
+    config()->set('africastalking.username', 'not_sandbox');
+
+    Saloon::fake([
+        CapabilityTokenRequest::class => MockResponse::make([
+            'clientName' => 'John.Doe',
+            'incoming' => true,
+            'lifeTimeSec' => '86400',
+            'outgoing' => true,
+            'token' => 'ATCAPtkn_somerandomtexthere',
+        ], 200),
+    ]);
+
+    $response = africastalking()->voice()
+        ->webrtc()
+        ->token();
+
+    expect($response)
+        ->toBeInstanceOf(CapabilityToken::class)
+        ->clientName->toBe('John.Doe')
+        ->incoming->toBeTrue()
+        ->outgoing->toBeTrue()
+        ->lifeTimeSec->toBe('86400')
+        ->token->toBe('ATCAPtkn_somerandomtexthere');
+});


### PR DESCRIPTION
Added `token()` as alias to `send()` on `WebRTCToken::class`.
This unlocks a fluent way to obtain a token as follows.

```php
$token = africastalking()
        ->voice()
        ->webrtc()
        ->for('John.Doe')
        ->token();
```
