### PR TITLE
call actions

### DIFF
--- a/src/Domain/VoiceCall.php
+++ b/src/Domain/VoiceCall.php
@@ -115,7 +115,7 @@ class VoiceCall
             'to' => $this->recipients
                 ->filter(fn(PhoneNumber $number) => $number->isValid())
                 ->map(fn(PhoneNumber $number) => $number->number)
-                ->implode(','),
+                ->toArray(),
         ];
 
         foreach ($this->actions as $action) {

--- a/src/Domain/VoiceCall.php
+++ b/src/Domain/VoiceCall.php
@@ -81,7 +81,7 @@ class VoiceCall
         $this->actions[] = Say::make(
             message: $message,
             playBeep: $playBeep,
-            voice: $voice
+            voice: $voice,
         );
 
         return $this;

--- a/src/Saloon/Requests/Voice/CallRequest.php
+++ b/src/Saloon/Requests/Voice/CallRequest.php
@@ -6,7 +6,6 @@ namespace SamuelMwangiW\Africastalking\Saloon\Requests\Voice;
 
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Http\Response;
-use Saloon\Traits\Body\HasFormBody;
 use Saloon\Traits\Body\HasJsonBody;
 use SamuelMwangiW\Africastalking\Enum\Service;
 use SamuelMwangiW\Africastalking\Saloon\Requests\BaseRequest;

--- a/src/Saloon/Requests/Voice/CallRequest.php
+++ b/src/Saloon/Requests/Voice/CallRequest.php
@@ -7,13 +7,14 @@ namespace SamuelMwangiW\Africastalking\Saloon\Requests\Voice;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Http\Response;
 use Saloon\Traits\Body\HasFormBody;
+use Saloon\Traits\Body\HasJsonBody;
 use SamuelMwangiW\Africastalking\Enum\Service;
 use SamuelMwangiW\Africastalking\Saloon\Requests\BaseRequest;
 use SamuelMwangiW\Africastalking\ValueObjects\VoiceCallResponse;
 
 class CallRequest extends BaseRequest implements HasBody
 {
-    use HasFormBody;
+    use HasJsonBody;
 
     public Service $service = Service::VOICE;
 

--- a/src/ValueObjects/Voice/CallActionItem.php
+++ b/src/ValueObjects/Voice/CallActionItem.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SamuelMwangiW\Africastalking\ValueObjects\Voice;
+
+interface CallActionItem
+{
+    public function buildJson(): array;
+}

--- a/src/ValueObjects/Voice/CallActionItem.php
+++ b/src/ValueObjects/Voice/CallActionItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SamuelMwangiW\Africastalking\ValueObjects\Voice;
 
 interface CallActionItem

--- a/src/ValueObjects/Voice/Dial.php
+++ b/src/ValueObjects/Voice/Dial.php
@@ -6,7 +6,7 @@ namespace SamuelMwangiW\Africastalking\ValueObjects\Voice;
 
 use Illuminate\Support\Collection;
 
-class Dial implements Action
+class Dial implements Action, CallActionItem
 {
     /**
      * @var Collection<int,string>
@@ -54,6 +54,16 @@ class Dial implements Action
         }
 
         return "<Dial{$options}/>";
+    }
+
+    public function buildJson(): array
+    {
+        return [
+            "actionType"=> "Dial",
+            "phoneNumbers" => $this->recipients->toArray(),
+            "record" => $this->record,
+            "sequential" => $this->sequential,
+        ];
     }
 
     public function phoneNumbers(array $phoneNumbers): static

--- a/src/ValueObjects/Voice/Dial.php
+++ b/src/ValueObjects/Voice/Dial.php
@@ -59,10 +59,10 @@ class Dial implements Action, CallActionItem
     public function buildJson(): array
     {
         return [
-            "actionType"=> "Dial",
-            "phoneNumbers" => $this->recipients->toArray(),
-            "record" => $this->record,
-            "sequential" => $this->sequential,
+            'actionType' => 'Dial',
+            'phoneNumbers' => $this->recipients->toArray(),
+            'record' => $this->record,
+            'sequential' => $this->sequential,
         ];
     }
 

--- a/src/ValueObjects/Voice/Play.php
+++ b/src/ValueObjects/Voice/Play.php
@@ -8,8 +8,7 @@ class Play implements Action, CallActionItem
 {
     public function __construct(
         private ?string $url = null,
-    ){
-    }
+    ) {}
 
     public static function make(string $url = ''): Play
     {
@@ -31,8 +30,8 @@ class Play implements Action, CallActionItem
     public function buildJson(): array
     {
         return [
-            "actionType"=> "Play",
-            "url" => $this->url,
+            'actionType' => 'Play',
+            'url' => $this->url,
         ];
     }
 }

--- a/src/ValueObjects/Voice/Play.php
+++ b/src/ValueObjects/Voice/Play.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace SamuelMwangiW\Africastalking\ValueObjects\Voice;
 
-class Play implements Action
+class Play implements Action, CallActionItem
 {
-    private string $url;
+    public function __construct(
+        private ?string $url = null,
+    ){
+    }
 
     public static function make(string $url = ''): Play
     {
-        return (new Play())->url($url);
+        return new Play($url);
     }
 
     public function url(string $url): static
@@ -23,5 +26,13 @@ class Play implements Action
     public function build(): string
     {
         return "<Play url=\"{$this->url}\"/>";
+    }
+
+    public function buildJson(): array
+    {
+        return [
+            "actionType"=> "Play",
+            "url" => $this->url,
+        ];
     }
 }

--- a/src/ValueObjects/Voice/Say.php
+++ b/src/ValueObjects/Voice/Say.php
@@ -6,7 +6,7 @@ namespace SamuelMwangiW\Africastalking\ValueObjects\Voice;
 
 use SamuelMwangiW\Africastalking\Exceptions\AfricastalkingException;
 
-class Say implements Action
+class Say implements Action, CallActionItem
 {
     private string $message;
     private bool $playBeep = false;
@@ -16,14 +16,15 @@ class Say implements Action
      * @throws AfricastalkingException
      */
     public static function make(
-        string|callable      $message,
-        bool        $playBeep = false,
-        string|null $voice = null,
-    ): Say {
+        string|callable $message,
+        bool            $playBeep = false,
+        string|null     $voice = null,
+    ): Say
+    {
         if (is_callable($message)) {
             $synthesisedSpeechParts = $message(new SynthesisedSpeech());
 
-            if ( ! $synthesisedSpeechParts instanceof SynthesisedSpeech) {
+            if (!$synthesisedSpeechParts instanceof SynthesisedSpeech) {
                 throw AfricastalkingException::notSynthesisedSpeech();
             }
 
@@ -68,7 +69,17 @@ class Say implements Action
             $options .= ' playBeep="true"';
         }
 
-        return "<Say{$options}>{$this->message}</Say>";
+        return "<Say{$options}>{$this->getMessage()}</Say>";
+    }
+
+    public function buildJson(): array
+    {
+        return [
+            "actionType" => "Say",
+            "text" => $this->getMessage(),
+            "voice" => $this->voice ?? "en-GB-Standard-B",
+            "playBeep" => $this->playBeep,
+        ];
     }
 
     public function getMessage(): string

--- a/src/ValueObjects/Voice/Say.php
+++ b/src/ValueObjects/Voice/Say.php
@@ -19,12 +19,11 @@ class Say implements Action, CallActionItem
         string|callable $message,
         bool            $playBeep = false,
         string|null     $voice = null,
-    ): Say
-    {
+    ): Say {
         if (is_callable($message)) {
             $synthesisedSpeechParts = $message(new SynthesisedSpeech());
 
-            if (!$synthesisedSpeechParts instanceof SynthesisedSpeech) {
+            if ( ! $synthesisedSpeechParts instanceof SynthesisedSpeech) {
                 throw AfricastalkingException::notSynthesisedSpeech();
             }
 
@@ -75,10 +74,10 @@ class Say implements Action, CallActionItem
     public function buildJson(): array
     {
         return [
-            "actionType" => "Say",
-            "text" => $this->getMessage(),
-            "voice" => $this->voice ?? "en-GB-Standard-B",
-            "playBeep" => $this->playBeep,
+            'actionType' => 'Say',
+            'text' => $this->getMessage(),
+            'voice' => $this->voice ?? 'en-GB-Standard-B',
+            'playBeep' => $this->playBeep,
         ];
     }
 

--- a/tests/Exceptionstest.php
+++ b/tests/Exceptionstest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 use SamuelMwangiW\Africastalking\Exceptions\AfricastalkingException;
 use SamuelMwangiW\Africastalking\ValueObjects\Voice\SynthesisedSpeech;
 
 it('is an exception')
     ->expect(AfricastalkingException::class)
-    ->toExtend(\Exception::class);
+    ->toExtend(Exception::class);
 
 it('thows the correct exception')
     ->expect(fn() => AfricastalkingException::notSynthesisedSpeech())
     ->toBeInstanceOf(AfricastalkingException::class)
     ->getMessage()->toBe(
-        'The returned object must be an instance of '. SynthesisedSpeech::class
+        'The returned object must be an instance of '.SynthesisedSpeech::class,
     );

--- a/tests/Exceptionstest.php
+++ b/tests/Exceptionstest.php
@@ -1,8 +1,15 @@
 <?php
 
-namespace SamuelMwangiW\Africastalking\Tests;
+use SamuelMwangiW\Africastalking\Exceptions\AfricastalkingException;
+use SamuelMwangiW\Africastalking\ValueObjects\Voice\SynthesisedSpeech;
 
-class Exceptionstest
-{
+it('is an exception')
+    ->expect(AfricastalkingException::class)
+    ->toExtend(\Exception::class);
 
-}
+it('thows the correct exception')
+    ->expect(fn() => AfricastalkingException::notSynthesisedSpeech())
+    ->toBeInstanceOf(AfricastalkingException::class)
+    ->getMessage()->toBe(
+        'The returned object must be an instance of '. SynthesisedSpeech::class
+    );

--- a/tests/Exceptionstest.php
+++ b/tests/Exceptionstest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SamuelMwangiW\Africastalking\Tests;
+
+class Exceptionstest
+{
+
+}

--- a/tests/Fixtures/Saloon/payments/wallet-failed.json
+++ b/tests/Fixtures/Saloon/payments/wallet-failed.json
@@ -1,0 +1,10 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Length": "46",
+        "Content-Type": "application\/json",
+        "Date": "Sat, 14 Dec 2024 19:08:26 GMT",
+        "Server": "akka-http\/10.2.10"
+    },
+    "data": "{\"status\":\"Failed\"}"
+}

--- a/tests/Fixtures/Saloon/voice/call-with-callactions.json
+++ b/tests/Fixtures/Saloon/voice/call-with-callactions.json
@@ -1,0 +1,12 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Date": "Sat, 14 Dec 2024 19:28:48 GMT",
+        "Content-Type": "application\/json",
+        "Content-Length": "138",
+        "Connection": "keep-alive",
+        "Server": "akka-http\/10.2.10",
+        "X-Current-Queue-Size": "1"
+    },
+    "data": "{\"entries\":[{\"phoneNumber\":\"+254722000000\",\"sessionId\":\"ATVId_96cd00fb425200566d5bc8012cd93f96\",\"status\":\"Queued\"}],\"errorMessage\":\"None\"}"
+}

--- a/tests/Unit/ValueObjects/VoiceCallTest.php
+++ b/tests/Unit/ValueObjects/VoiceCallTest.php
@@ -42,7 +42,7 @@ it('sets a call recipient', function (string $phone): void {
         ->data()
         ->toBeArray()
         ->toHaveKey('to')
-        ->toMatchArray(['to' => $phone]);
+        ->toMatchArray(['to' => [$phone]]);
 })->with('phone-numbers');
 
 it('sets a call recipient from PhoneNumber object', function (string $phone): void {
@@ -50,7 +50,7 @@ it('sets a call recipient from PhoneNumber object', function (string $phone): vo
         ->data()
         ->toBeArray()
         ->toHaveKey('to')
-        ->toMatchArray(['to' => $phone]);
+        ->toMatchArray(['to' => [$phone]]);
 })->with('phone-numbers')
 ;
 
@@ -65,7 +65,7 @@ it('sets a call recipients from array', function (): void {
         ->data()
         ->toBeArray()
         ->toHaveKey('to')
-        ->toMatchArray(['to' => implode(',', $recipients)]);
+        ->toMatchArray(['to' => $recipients]);
 });
 
 it('sets a call clientRequestId', function (string $id): void {

--- a/tests/VoiceTest.php
+++ b/tests/VoiceTest.php
@@ -124,7 +124,7 @@ it('sets voiceActions fluently', function (string $phone): void {
         ->toBe([
             'from' => '+254711000000',
             'clientRequestId' => $id,
-            'to' => "{$phone},+254712345678",
+            'to' => [$phone, "+254712345678"],
             'callActions' => [
                 [
                     'actionType' => 'Say',
@@ -159,6 +159,23 @@ it('makes a call', function (string $phone): void {
         ->recipients->toBeInstanceOf(Collection::class)
         ->toHaveCount(3)
         ->and($response->errorMessage)->toBeIn(['None', 'Invalid callbackUrl: ', 'Invalid callerId: ']);
+})->with('phone-numbers');
+
+it('makes a call with call actions', function (string $phone): void {
+    Saloon::fake([
+        CallRequest::class => MockResponse::fixture('voice/call-with-callactions'),
+    ]);
+
+    $response = africastalking()->voice()
+        ->call(['+254720404119'])
+        ->say('Hey there. Your code is 1 2 3 4')
+        ->dial(['+254711082000'])
+        ->send();
+
+    expect($response)
+        ->toBeInstanceOf(VoiceCallResponse::class)
+        ->toHaveKeys(['recipients', 'errorMessage'])
+        ->recipients->toBeInstanceOf(Collection::class);
 })->with('phone-numbers');
 
 it('initiates a webrtc object')

--- a/tests/VoiceTest.php
+++ b/tests/VoiceTest.php
@@ -124,7 +124,7 @@ it('sets voiceActions fluently', function (string $phone): void {
         ->toBe([
             'from' => '+254711000000',
             'clientRequestId' => $id,
-            'to' => [$phone, "+254712345678"],
+            'to' => [$phone, '+254712345678'],
             'callActions' => [
                 [
                     'actionType' => 'Say',
@@ -142,7 +142,7 @@ it('sets voiceActions fluently', function (string $phone): void {
                     'record' => false,
                     'sequential' => true,
                 ],
-            ]
+            ],
         ]);
 })->with('phone-numbers');
 
@@ -274,7 +274,7 @@ it('fetches the queue for a given number', function ($numbers): void {
     'array of numbers' => ['+254711082000', '+254711082111'],
 ]);
 
-test('calls returns null while not faking', function () {
+test('calls returns null while not faking', function (): void {
     $payload = africastalking()->voice()
         ->call()
         ->to(['+254712345678'])

--- a/tests/WalletTest.php
+++ b/tests/WalletTest.php
@@ -38,3 +38,11 @@ it('can fetch balance via helper', function (): void {
 
     expect($balance)->toBeInstanceOf(Balance::class);
 });
+
+it('throws when failed to fetch balance', function (): void {
+    Saloon::fake([
+        WalletBalanceRequest::class => MockResponse::fixture('payments/wallet-failed'),
+    ]);
+
+    africastalking()->wallet()->balance();
+})->throws(\Exception::class, 'Failed to fetch wallet balance');

--- a/tests/WalletTest.php
+++ b/tests/WalletTest.php
@@ -45,4 +45,4 @@ it('throws when failed to fetch balance', function (): void {
     ]);
 
     africastalking()->wallet()->balance();
-})->throws(\Exception::class, 'Failed to fetch wallet balance');
+})->throws(Exception::class, 'Failed to fetch wallet balance');


### PR DESCRIPTION
This PR provides an implementation to the recently introduced call actions feature that makes it easy to do call broadcasts and sending voice OTPs by including the message in the call request.

[Medium article describing the feature](https://blog.africastalking.com/make-call-callactions-submenu-91e09aa6ef39)

```PHP
africastalking()->voice()
        ->call()
        ->to([$phone, '+254712345678'])
        ->say('Hey there. Your code is 1 2 3 4. Your code is 1 2 3 4')
        ->play('https://example.com/broadcast-message.wav')
        ->dial(['+254202227436'])
        ->send();
```

closes #1 