### PR TITLE
Upgrade to to laravel-plugin 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "illuminate/contracts": "^12.39||^13.0",
-        "saloonphp/laravel-plugin": "^3.5",
+        "saloonphp/laravel-plugin": "^4.0",
         "spatie/laravel-package-tools": "^1.93"
     },
     "require-dev": {


### PR DESCRIPTION
Saloon version four released to resolve three breaking CVE issues published on the 25th March 2026. [See](https://docs.saloon.dev/upgrade/upgrading-from-v3-to-v4)