### PR TITLE
Security update: Bump saloon php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "illuminate/contracts": "^12.39||^13.0",
-        "saloonphp/laravel-plugin": "^3.5",
+        "saloonphp/laravel-plugin": "^4.0",
         "spatie/laravel-package-tools": "^1.93"
     },
     "require-dev": {


### PR DESCRIPTION
This is a security update that bumps the underlying library version.

There is no api change from the part of this SDK or Saloon.

See: 
1. CVE-2026-33942
2. [CVE-2026-33182](https://github.com/advisories/GHSA-c83f-3xp6-hfcp)
3. [CVE-2026-33183](https://github.com/advisories/GHSA-f7xc-5852-fj99)