### PR TITLE
capability token

### DIFF
--- a/src/Facades/Africastalking.php
+++ b/src/Facades/Africastalking.php
@@ -13,6 +13,10 @@ use SamuelMwangiW\Africastalking\Africastalking as BaseClass;
  */
 class Africastalking extends Facade
 {
+    public static function fake(): void
+    {
+        // @todo: implement fake
+    }
     protected static function getFacadeAccessor(): string
     {
         return BaseClass::class;

--- a/src/Facades/Africastalking.php
+++ b/src/Facades/Africastalking.php
@@ -13,10 +13,7 @@ use SamuelMwangiW\Africastalking\Africastalking as BaseClass;
  */
 class Africastalking extends Facade
 {
-    public static function fake(): void
-    {
-        // @todo: implement fake
-    }
+    // @todo: implement fake
     protected static function getFacadeAccessor(): string
     {
         return BaseClass::class;

--- a/src/ValueObjects/CapabilityToken.php
+++ b/src/ValueObjects/CapabilityToken.php
@@ -7,15 +7,15 @@ namespace SamuelMwangiW\Africastalking\ValueObjects;
 use Saloon\Http\Response;
 use SamuelMwangiW\Africastalking\Contracts\DTOContract;
 
-class CapabilityToken implements DTOContract
+readonly class CapabilityToken implements DTOContract
 {
     public function __construct(
-        public readonly string $clientName,
-        public readonly bool $incoming,
-        public readonly int $lifeTimeSec,
-        public readonly bool $outgoing,
-        public readonly string $token,
-        public readonly ?string $phoneNumber = null,
+        public string $clientName,
+        public bool   $incoming,
+        public int    $lifeTimeSec,
+        public bool   $outgoing,
+        public string $token,
+        public string $phoneNumber,
     ) {}
 
     public function __toString(): string

--- a/src/ValueObjects/CapabilityToken.php
+++ b/src/ValueObjects/CapabilityToken.php
@@ -35,7 +35,7 @@ readonly class CapabilityToken implements DTOContract
         ];
     }
 
-    public static function fromSaloon(Response $response, ?string $phoneNumber = null): CapabilityToken
+    public static function fromSaloon(Response $response, string $phoneNumber): CapabilityToken
     {
         $data = $response->json();
 

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -15,6 +15,10 @@ class TestRequest extends Request implements HasBody
 {
     use HasJsonBody;
 
+    public function __construct(public string $phoneNumber = '')
+    {
+    }
+
     protected Method $method = Method::POST;
 
     public function resolveEndpoint(): string
@@ -24,6 +28,6 @@ class TestRequest extends Request implements HasBody
 
     public function createDtoFromResponse(Response $response): CapabilityToken
     {
-        return CapabilityToken::fromSaloon($response);
+        return CapabilityToken::fromSaloon($response, $this->phoneNumber);
     }
 }

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -15,11 +15,9 @@ class TestRequest extends Request implements HasBody
 {
     use HasJsonBody;
 
-    public function __construct(public string $phoneNumber = '')
-    {
-    }
-
     protected Method $method = Method::POST;
+
+    public function __construct(public string $phoneNumber = '') {}
 
     public function resolveEndpoint(): string
     {

--- a/tests/Unit/SaloonTest.php
+++ b/tests/Unit/SaloonTest.php
@@ -20,7 +20,7 @@ it('fakes requests', function (): void {
     ]);
 
     $connector = new TestConnector();
-    $response = $connector->send(TestRequest::make())->dto();
+    $response = $connector->send(TestRequest::make('+254722123456'))->dto();
 
     expect($response)
         ->toBeInstanceOf(CapabilityToken::class)
@@ -28,5 +28,6 @@ it('fakes requests', function (): void {
         ->incoming->toBeTrue()
         ->outgoing->toBeTrue()
         ->lifeTimeSec->toBeInt()->toBe(86400)
-        ->token->toBe('ATCAPtkn_somerandomtexthere');
+        ->token->toBe('ATCAPtkn_somerandomtexthere')
+        ->phoneNumber->toBe('+254722123456');
 });


### PR DESCRIPTION
## What?

This is a paper-cut PR in preparation for the next major version.

## Why?

The api response does not indicate for which phone number the capability token was generated. As such, troubleshooting an issue forces one to send the configured phone number or build a new response just to send to the front-end client.

This change wraps the value into the value object returned. 

## Why not optional?

The class is fully internal and there is no API to construct it in user-land. I doubt anyone is overriding the class in the wild but given we shall be tagging a major version soon, we shall endeavor to document the breaking change for such users

