### PR TITLE
Add support for transferring an active call

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
         items: [
           { text: 'Making Calls', link: '/voice/calls' },
           { text: 'Voice Responses (IVR)', link: '/voice/responses' },
+          { text: 'Transferring an Active Call', link: '/voice/call-transfer' },
           { text: 'Synthesized Speech', link: '/voice/attributes' },
         ]
       },

--- a/docs/voice/call-transfer.md
+++ b/docs/voice/call-transfer.md
@@ -8,7 +8,7 @@ This is useful for scenarios like transferring a customer from a first-line agen
 
 ```php
 africastalking()->voice()
-    ->transferCall($sessionId)
+    ->transfer($sessionId)
     ->to('+254728900922')
     ->send();
 ```
@@ -42,11 +42,12 @@ class TransferToSupervisorController
 
 | Method | Description |
 |---|---|
-| `transferCall(?string $sessionId)` / `transfer(?string $sessionId)` | Start building a transfer for the given call session |
+| `transfer(?string $sessionId)` | Start building a transfer for the given call session |
 | `to(string $phoneNumber)` | The phone number to transfer the call to |
 | `callLeg(string\|CallLeg $leg)` | Which leg to transfer — `CallLeg::CALLER` or `CallLeg::CALLEE`. Defaults to the callee if not set |
 | `holdMusic(?string $url)` | A media file URL to play to the other party while the transfer is in progress |
 | `send()` | Dispatch the transfer request |
+| `transferCall(?string $sessionId)` | Alias for `transfer()` |
 
 ## Choosing Which Leg to Transfer
 
@@ -56,7 +57,7 @@ By default, Africa's Talking transfers the callee leg. Use `callLeg()` to transf
 use SamuelMwangiW\Africastalking\Enum\CallLeg;
 
 africastalking()->voice()
-    ->transferCall($sessionId)
+    ->transfer($sessionId)
     ->to('+254728900922')
     ->callLeg(CallLeg::CALLER)
     ->send();
@@ -66,7 +67,7 @@ africastalking()->voice()
 
 ```php
 africastalking()->voice()
-    ->transferCall($sessionId)
+    ->transfer($sessionId)
     ->to('+254728900922')
     ->holdMusic('https://example.com/hold-music.mp3')
     ->send();
@@ -78,7 +79,7 @@ africastalking()->voice()
 
 ```php
 $response = africastalking()->voice()
-    ->transferCall($sessionId)
+    ->transfer($sessionId)
     ->to('+254728900922')
     ->send();
 
@@ -108,7 +109,7 @@ class HandleDtmfController
         $supervisor = Supervisor::query()->onDuty()->first();
 
         africastalking()->voice()
-            ->transferCall($request->id())
+            ->transfer($request->id())
             ->to($supervisor->phone)
             ->holdMusic('https://example.com/hold-music.mp3')
             ->send();

--- a/docs/voice/call-transfer.md
+++ b/docs/voice/call-transfer.md
@@ -29,7 +29,7 @@ class TransferToSupervisorController
     public function __invoke(VoiceEventRequest $request)
     {
         africastalking()->voice()
-            ->transferCall($request->id()) // sessionId
+            ->transfer($request->id()) // sessionId
             ->to('+254728900922')
             ->send();
 
@@ -42,7 +42,7 @@ class TransferToSupervisorController
 
 | Method | Description |
 |---|---|
-| `transferCall(?string $sessionId)` | Start building a transfer for the given call session |
+| `transferCall(?string $sessionId)` / `transfer(?string $sessionId)` | Start building a transfer for the given call session |
 | `to(string $phoneNumber)` | The phone number to transfer the call to |
 | `callLeg(string\|CallLeg $leg)` | Which leg to transfer — `CallLeg::CALLER` or `CallLeg::CALLEE`. Defaults to the callee if not set |
 | `holdMusic(?string $url)` | A media file URL to play to the other party while the transfer is in progress |

--- a/docs/voice/call-transfer.md
+++ b/docs/voice/call-transfer.md
@@ -1,0 +1,123 @@
+# Transferring an Active Call
+
+`dial()` and `redirect()` are XML instructions your callback returns to control a call as it's being set up. Call transfer is different: it's a direct API call you make to move an **already in-progress, two-legged call** — for example, one you connected earlier with `dial()` — to a different number, without ending the call.
+
+This is useful for scenarios like transferring a customer from a first-line agent to a supervisor, or moving a caller between departments mid-conversation.
+
+## Basic Example
+
+```php
+africastalking()->voice()
+    ->transferCall($sessionId)
+    ->to('+254728900922')
+    ->send();
+```
+
+::: warning Requires a Two-Legged Call
+The call being transferred must already have two active legs — for example, a caller connected to an agent via `dial()`. Attempting to transfer a call that hasn't been connected to a second party will fail.
+:::
+
+## Getting the Session ID
+
+The `sessionId` identifies the ongoing call and comes from Africa's Talking's callback payload. If you're inside a voice event handler, read it off the request:
+
+```php
+use SamuelMwangiW\Africastalking\Http\Requests\VoiceEventRequest;
+
+class TransferToSupervisorController
+{
+    public function __invoke(VoiceEventRequest $request)
+    {
+        africastalking()->voice()
+            ->transferCall($request->id()) // sessionId
+            ->to('+254728900922')
+            ->send();
+
+        return response('OK');
+    }
+}
+```
+
+## Method Reference
+
+| Method | Description |
+|---|---|
+| `transferCall(?string $sessionId)` | Start building a transfer for the given call session |
+| `to(string $phoneNumber)` | The phone number to transfer the call to |
+| `callLeg(string\|CallLeg $leg)` | Which leg to transfer — `CallLeg::CALLER` or `CallLeg::CALLEE`. Defaults to the callee if not set |
+| `holdMusic(?string $url)` | A media file URL to play to the other party while the transfer is in progress |
+| `send()` | Dispatch the transfer request |
+
+## Choosing Which Leg to Transfer
+
+By default, Africa's Talking transfers the callee leg. Use `callLeg()` to transfer the caller instead, passing either the `CallLeg` enum or its raw string value:
+
+```php
+use SamuelMwangiW\Africastalking\Enum\CallLeg;
+
+africastalking()->voice()
+    ->transferCall($sessionId)
+    ->to('+254728900922')
+    ->callLeg(CallLeg::CALLER)
+    ->send();
+```
+
+## Playing Hold Music
+
+```php
+africastalking()->voice()
+    ->transferCall($sessionId)
+    ->to('+254728900922')
+    ->holdMusic('https://example.com/hold-music.mp3')
+    ->send();
+```
+
+## The Response
+
+`send()` returns a `CallTransferResponse`:
+
+```php
+$response = africastalking()->voice()
+    ->transferCall($sessionId)
+    ->to('+254728900922')
+    ->send();
+
+$response->status;         // Status::SUCCESS
+$response->errorMessage;   // "None"
+$response->isSuccessful(); // true
+```
+
+## Example: Transfer to a Supervisor on Request
+
+```php
+<?php
+
+namespace App\Http\Controllers\CallCenter;
+
+use App\Models\Supervisor;
+use SamuelMwangiW\Africastalking\Http\Requests\VoiceEventRequest;
+
+class HandleDtmfController
+{
+    public function __invoke(VoiceEventRequest $request)
+    {
+        if ('9' !== $request->input('dtmfDigits')) {
+            return response('OK');
+        }
+
+        $supervisor = Supervisor::query()->onDuty()->first();
+
+        africastalking()->voice()
+            ->transferCall($request->id())
+            ->to($supervisor->phone)
+            ->holdMusic('https://example.com/hold-music.mp3')
+            ->send();
+
+        return response('OK');
+    }
+}
+```
+
+::: tip
+See the [Africa's Talking Call Transfer documentation](https://developers.africastalking.com/docs/voice/call_transfer) for the underlying API details.
+:::

--- a/docs/voice/call-transfer.md
+++ b/docs/voice/call-transfer.md
@@ -44,14 +44,14 @@ class TransferToSupervisorController
 |---|---|
 | `transfer(?string $sessionId)` | Start building a transfer for the given call session |
 | `to(string $phoneNumber)` | The phone number to transfer the call to |
-| `callLeg(string\|CallLeg $leg)` | Which leg to transfer — `CallLeg::CALLER` or `CallLeg::CALLEE`. Defaults to the callee if not set |
+| `leg(string\|CallLeg $leg)` | Which leg to transfer — `CallLeg::CALLER` or `CallLeg::CALLEE`. Defaults to the callee if not set |
 | `holdMusic(?string $url)` | A media file URL to play to the other party while the transfer is in progress |
 | `send()` | Dispatch the transfer request |
 | `transferCall(?string $sessionId)` | Alias for `transfer()` |
 
 ## Choosing Which Leg to Transfer
 
-By default, Africa's Talking transfers the callee leg. Use `callLeg()` to transfer the caller instead, passing either the `CallLeg` enum or its raw string value:
+By default, Africa's Talking transfers the callee leg. Use `leg()` to transfer the caller instead, passing either the `CallLeg` enum or its raw string value:
 
 ```php
 use SamuelMwangiW\Africastalking\Enum\CallLeg;
@@ -59,7 +59,7 @@ use SamuelMwangiW\Africastalking\Enum\CallLeg;
 africastalking()->voice()
     ->transfer($sessionId)
     ->to('+254728900922')
-    ->callLeg(CallLeg::CALLER)
+    ->leg(CallLeg::CALLER)
     ->send();
 ```
 

--- a/docs/voice/responses.md
+++ b/docs/voice/responses.md
@@ -139,6 +139,8 @@ class ForwardCallsController
 }
 ```
 
+Once connected, that call can later be moved to a different number without hanging up — see [Transferring an Active Call](./call-transfer).
+
 ### Reject After Hours
 
 ```php

--- a/src/Domain/CallTransfer.php
+++ b/src/Domain/CallTransfer.php
@@ -12,7 +12,7 @@ class CallTransfer
 {
     private ?string $sessionId = null;
     private ?string $phoneNumber = null;
-    private ?CallLeg $callLeg = null;
+    private CallLeg $callLeg = CallLeg::CALLEE;
     private ?string $holdMusicUrl = null;
 
     public function session(?string $sessionId): static
@@ -53,11 +53,11 @@ class CallTransfer
 
     private function data(): array
     {
-        return [
+        return array_filter([
             'sessionId' => $this->sessionId,
             'phoneNumber' => $this->phoneNumber,
-            'callLeg' => $this->callLeg?->value,
+            'callLeg' => $this->callLeg->value,
             'holdMusicUrl' => $this->holdMusicUrl,
-        ];
+        ]);
     }
 }

--- a/src/Domain/CallTransfer.php
+++ b/src/Domain/CallTransfer.php
@@ -29,9 +29,9 @@ class CallTransfer
         return $this;
     }
 
-    public function callLeg(string|CallLeg $callLeg): static
+    public function leg(string|CallLeg $leg): static
     {
-        $this->callLeg = is_string($callLeg) ? CallLeg::from($callLeg) : $callLeg;
+        $this->callLeg = is_string($leg) ? CallLeg::from($leg) : $leg;
 
         return $this;
     }

--- a/src/Domain/CallTransfer.php
+++ b/src/Domain/CallTransfer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamuelMwangiW\Africastalking\Domain;
+
+use SamuelMwangiW\Africastalking\Enum\CallLeg;
+use SamuelMwangiW\Africastalking\Saloon\Requests\Voice\CallTransferRequest;
+use SamuelMwangiW\Africastalking\ValueObjects\CallTransferResponse;
+
+class CallTransfer
+{
+    private ?string $sessionId = null;
+    private ?string $phoneNumber = null;
+    private ?CallLeg $callLeg = null;
+    private ?string $holdMusicUrl = null;
+
+    public function session(?string $sessionId): static
+    {
+        $this->sessionId = $sessionId;
+
+        return $this;
+    }
+
+    public function to(string $phoneNumber): static
+    {
+        $this->phoneNumber = $phoneNumber;
+
+        return $this;
+    }
+
+    public function callLeg(string|CallLeg $callLeg): static
+    {
+        $this->callLeg = is_string($callLeg) ? CallLeg::from($callLeg) : $callLeg;
+
+        return $this;
+    }
+
+    public function holdMusic(?string $url): static
+    {
+        $this->holdMusicUrl = $url;
+
+        return $this;
+    }
+
+    public function send(): CallTransferResponse
+    {
+        return CallTransferRequest::make($this->data())
+            ->send()
+            ->throw()
+            ->dto();
+    }
+
+    private function data(): array
+    {
+        return [
+            'sessionId' => $this->sessionId,
+            'phoneNumber' => $this->phoneNumber,
+            'callLeg' => $this->callLeg?->value,
+            'holdMusicUrl' => $this->holdMusicUrl,
+        ];
+    }
+}

--- a/src/Domain/Voice.php
+++ b/src/Domain/Voice.php
@@ -36,4 +36,9 @@ class Voice
     {
         return app(QueueStatus::class)->for($phoneNumbers);
     }
+
+    public function transferCall(?string $sessionId = null): CallTransfer
+    {
+        return app(CallTransfer::class)->session($sessionId);
+    }
 }

--- a/src/Domain/Voice.php
+++ b/src/Domain/Voice.php
@@ -41,4 +41,9 @@ class Voice
     {
         return app(CallTransfer::class)->session($sessionId);
     }
+
+    public function transfer(?string $sessionId = null): CallTransfer
+    {
+        return $this->transferCall($sessionId);
+    }
 }

--- a/src/Enum/CallLeg.php
+++ b/src/Enum/CallLeg.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamuelMwangiW\Africastalking\Enum;
+
+enum CallLeg: string
+{
+    case CALLER = 'caller';
+    case CALLEE = 'callee';
+}

--- a/src/Saloon/Requests/Voice/CallTransferRequest.php
+++ b/src/Saloon/Requests/Voice/CallTransferRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamuelMwangiW\Africastalking\Saloon\Requests\Voice;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasFormBody;
+use SamuelMwangiW\Africastalking\Enum\Service;
+use SamuelMwangiW\Africastalking\Saloon\Requests\BaseRequest;
+use SamuelMwangiW\Africastalking\ValueObjects\CallTransferResponse;
+
+class CallTransferRequest extends BaseRequest implements HasBody
+{
+    use HasFormBody;
+
+    public Service $service = Service::VOICE;
+
+    public function __construct(private readonly array $data) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/callTransfer';
+    }
+
+    public function defaultBody(): array
+    {
+        return array_merge(
+            array_filter($this->data),
+            ['username' => $this->username()],
+        );
+    }
+
+    public function createDtoFromResponse(Response $response): CallTransferResponse
+    {
+        return CallTransferResponse::make($response->json());
+    }
+}

--- a/src/Saloon/Requests/Voice/CallTransferRequest.php
+++ b/src/Saloon/Requests/Voice/CallTransferRequest.php
@@ -27,7 +27,7 @@ class CallTransferRequest extends BaseRequest implements HasBody
     public function defaultBody(): array
     {
         return array_merge(
-            array_filter($this->data),
+            $this->data,
             ['username' => $this->username()],
         );
     }

--- a/src/ValueObjects/CallTransferResponse.php
+++ b/src/ValueObjects/CallTransferResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamuelMwangiW\Africastalking\ValueObjects;
+
+use SamuelMwangiW\Africastalking\Contracts\DTOContract;
+use SamuelMwangiW\Africastalking\Enum\Status;
+
+class CallTransferResponse implements DTOContract
+{
+    public function __construct(
+        public readonly Status $status,
+        public readonly string $errorMessage,
+    ) {}
+
+    public function __toString(): string
+    {
+        return (string) json_encode($this->__toArray());
+    }
+
+    public function __toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'errorMessage' => $this->errorMessage,
+        ];
+    }
+
+    public static function make(array $attributes): CallTransferResponse
+    {
+        $data = data_get($attributes, 'callTransferResponse', $attributes);
+
+        return new CallTransferResponse(
+            status: Status::from(data_get($data, 'status')),
+            errorMessage: data_get($data, 'errorMessage', ''),
+        );
+    }
+
+    public function isSuccessful(): bool
+    {
+        return Status::SUCCESS === $this->status;
+    }
+}

--- a/tests/Feature/CallTransferTest.php
+++ b/tests/Feature/CallTransferTest.php
@@ -17,6 +17,28 @@ it('resolves a CallTransfer instance', function (): void {
     expect(Africastalking::voice()->transferCall())->toBeInstanceOf(CallTransfer::class);
 });
 
+it('resolves a CallTransfer instance via the transfer() alias', function (): void {
+    expect(Africastalking::voice()->transfer())->toBeInstanceOf(CallTransfer::class);
+});
+
+it('transfers a call via the transfer() alias, sending the same sessionId', function (): void {
+    Saloon::fake([
+        CallTransferRequest::class => function (PendingRequest $pendingRequest) {
+            expect($pendingRequest->body()?->get('sessionId'))->toBe('ATVId_47ef478e918923e7b2d0921ebd5b66a6');
+
+            return MockResponse::fixture('voice/call-transfer');
+        },
+    ]);
+
+    $response = Africastalking::voice()
+        ->transfer('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+        ->to('+254728900922')
+        ->send();
+
+    expect($response)->toBeInstanceOf(CallTransferResponse::class)
+        ->status->toBe(Status::SUCCESS);
+});
+
 it('transfers a call to another number', function (): void {
     Saloon::fake([
         CallTransferRequest::class => MockResponse::fixture('voice/call-transfer'),

--- a/tests/Feature/CallTransferTest.php
+++ b/tests/Feature/CallTransferTest.php
@@ -73,7 +73,7 @@ it('sends the sessionId, phoneNumber, username and a default callLeg of callee i
         ->send();
 });
 
-it('sends the callLeg when set, accepting either a string or the CallLeg enum', function (string|CallLeg $callLeg): void {
+it('sends the callLeg when set via leg(), accepting either a string or the CallLeg enum', function (string|CallLeg $leg): void {
     Saloon::fake([
         CallTransferRequest::class => function (PendingRequest $pendingRequest) {
             expect($pendingRequest->body()?->get('callLeg'))->toBe('caller');
@@ -85,7 +85,7 @@ it('sends the callLeg when set, accepting either a string or the CallLeg enum', 
     Africastalking::voice()
         ->transferCall('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
         ->to('+254728900922')
-        ->callLeg($callLeg)
+        ->leg($leg)
         ->send();
 })->with([
     'string' => 'caller',

--- a/tests/Feature/CallTransferTest.php
+++ b/tests/Feature/CallTransferTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Exceptions\Request\ClientException;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+use Saloon\Laravel\Facades\Saloon;
+use SamuelMwangiW\Africastalking\Domain\CallTransfer;
+use SamuelMwangiW\Africastalking\Enum\CallLeg;
+use SamuelMwangiW\Africastalking\Enum\Status;
+use SamuelMwangiW\Africastalking\Facades\Africastalking;
+use SamuelMwangiW\Africastalking\Saloon\Requests\Voice\CallTransferRequest;
+use SamuelMwangiW\Africastalking\ValueObjects\CallTransferResponse;
+
+it('resolves a CallTransfer instance', function (): void {
+    expect(Africastalking::voice()->transferCall())->toBeInstanceOf(CallTransfer::class);
+});
+
+it('transfers a call to another number', function (): void {
+    Saloon::fake([
+        CallTransferRequest::class => MockResponse::fixture('voice/call-transfer'),
+    ]);
+
+    $response = Africastalking::voice()
+        ->transferCall('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+        ->to('+254728900922')
+        ->send();
+
+    expect($response)->toBeInstanceOf(CallTransferResponse::class)
+        ->status->toBe(Status::SUCCESS)
+        ->and($response->isSuccessful())->toBeTrue();
+});
+
+it('sends the sessionId, phoneNumber and username in the request body', function (): void {
+    Saloon::fake([
+        CallTransferRequest::class => function (PendingRequest $pendingRequest) {
+            expect($pendingRequest->body()?->get('sessionId'))->toBe('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+                ->and($pendingRequest->body()?->get('phoneNumber'))->toBe('+254728900922')
+                ->and($pendingRequest->body()?->get('username'))->not->toBeNull()
+                ->and($pendingRequest->body()?->all())->not->toHaveKey('callLeg')
+                ->and($pendingRequest->body()?->all())->not->toHaveKey('holdMusicUrl');
+
+            return MockResponse::fixture('voice/call-transfer');
+        },
+    ]);
+
+    Africastalking::voice()
+        ->transferCall('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+        ->to('+254728900922')
+        ->send();
+});
+
+it('sends the callLeg when set, accepting either a string or the CallLeg enum', function (string|CallLeg $callLeg): void {
+    Saloon::fake([
+        CallTransferRequest::class => function (PendingRequest $pendingRequest) {
+            expect($pendingRequest->body()?->get('callLeg'))->toBe('caller');
+
+            return MockResponse::fixture('voice/call-transfer');
+        },
+    ]);
+
+    Africastalking::voice()
+        ->transferCall('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+        ->to('+254728900922')
+        ->callLeg($callLeg)
+        ->send();
+})->with([
+    'string' => 'caller',
+    'enum' => CallLeg::CALLER,
+]);
+
+it('sends the holdMusicUrl when set', function (): void {
+    Saloon::fake([
+        CallTransferRequest::class => function (PendingRequest $pendingRequest) {
+            expect($pendingRequest->body()?->get('holdMusicUrl'))->toBe('https://example.com/hold-music.mp3');
+
+            return MockResponse::fixture('voice/call-transfer');
+        },
+    ]);
+
+    Africastalking::voice()
+        ->transferCall('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
+        ->to('+254728900922')
+        ->holdMusic('https://example.com/hold-music.mp3')
+        ->send();
+});
+
+it('throws when the transfer request fails', function (): void {
+    Saloon::fake([
+        CallTransferRequest::class => MockResponse::make(
+            body: "Request is missing required form field 'sessionId'",
+            status: 400,
+        ),
+    ]);
+
+    Africastalking::voice()
+        ->transferCall()
+        ->to('+254728900922')
+        ->send();
+})->throws(ClientException::class);

--- a/tests/Feature/CallTransferTest.php
+++ b/tests/Feature/CallTransferTest.php
@@ -32,13 +32,13 @@ it('transfers a call to another number', function (): void {
         ->and($response->isSuccessful())->toBeTrue();
 });
 
-it('sends the sessionId, phoneNumber and username in the request body', function (): void {
+it('sends the sessionId, phoneNumber, username and a default callLeg of callee in the request body', function (): void {
     Saloon::fake([
         CallTransferRequest::class => function (PendingRequest $pendingRequest) {
             expect($pendingRequest->body()?->get('sessionId'))->toBe('ATVId_47ef478e918923e7b2d0921ebd5b66a6')
                 ->and($pendingRequest->body()?->get('phoneNumber'))->toBe('+254728900922')
                 ->and($pendingRequest->body()?->get('username'))->not->toBeNull()
-                ->and($pendingRequest->body()?->all())->not->toHaveKey('callLeg')
+                ->and($pendingRequest->body()?->get('callLeg'))->toBe('callee')
                 ->and($pendingRequest->body()?->all())->not->toHaveKey('holdMusicUrl');
 
             return MockResponse::fixture('voice/call-transfer');

--- a/tests/Fixtures/Saloon/voice/call-transfer.json
+++ b/tests/Fixtures/Saloon/voice/call-transfer.json
@@ -1,0 +1,1 @@
+{"statusCode":200,"headers":{"Date":"Tue, 04 Aug 2026 09:12:00 GMT","Content-Type":"application\/json","Content-Length":"64","Connection":"keep-alive","Server":"akka-http\/10.2.7"},"data":"{\"callTransferResponse\":{\"errorMessage\":\"None\",\"status\":\"Success\"}}"}

--- a/tests/Unit/ValueObjects/CallTransferResponseTest.php
+++ b/tests/Unit/ValueObjects/CallTransferResponseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use SamuelMwangiW\Africastalking\Contracts\DTOContract;
+use SamuelMwangiW\Africastalking\Enum\Status;
+use SamuelMwangiW\Africastalking\ValueObjects\CallTransferResponse;
+
+it('can be constructed')
+    ->expect(fn() => new CallTransferResponse(
+        status: Status::SUCCESS,
+        errorMessage: 'None',
+    ))
+    ->toBeInstanceOf(CallTransferResponse::class)
+    ->status->toBe(Status::SUCCESS)
+    ->errorMessage->toBe('None');
+
+it('can be constructed statically from the nested callTransferResponse shape')
+    ->expect(fn() => CallTransferResponse::make([
+        'callTransferResponse' => [
+            'status' => Status::SUCCESS->value,
+            'errorMessage' => 'None',
+        ],
+    ]))
+    ->toBeInstanceOf(CallTransferResponse::class)
+    ->status->toBe(Status::SUCCESS)
+    ->errorMessage->toBe('None');
+
+it('can be constructed statically from an already-unwrapped array')
+    ->expect(fn() => CallTransferResponse::make([
+        'status' => Status::FAILED->value,
+        'errorMessage' => 'InvalidPhoneNumber',
+    ]))
+    ->toBeInstanceOf(CallTransferResponse::class)
+    ->status->toBe(Status::FAILED)
+    ->errorMessage->toBe('InvalidPhoneNumber');
+
+it('implements DTO contract')
+    ->expect(fn() => new CallTransferResponse(
+        status: Status::SUCCESS,
+        errorMessage: 'None',
+    ))
+    ->toBeInstanceOf(DTOContract::class);
+
+it('can be cast to array')
+    ->expect(fn() => new CallTransferResponse(
+        status: Status::SUCCESS,
+        errorMessage: 'None',
+    ))
+    ->__toArray()->toBeArray()->toMatchArray(['status' => Status::SUCCESS, 'errorMessage' => 'None']);
+
+it('can be cast to string', function (): void {
+    $object = new CallTransferResponse(
+        status: Status::SUCCESS,
+        errorMessage: 'None',
+    );
+
+    expect((string) $object)
+        ->toBeString()
+        ->toBe($object->__toString())
+        ->toBe('{"status":"Success","errorMessage":"None"}');
+});
+
+it('is successful when the status is Success')
+    ->expect(fn() => new CallTransferResponse(status: Status::SUCCESS, errorMessage: 'None'))
+    ->isSuccessful()->toBeTrue();
+
+it('is not successful when the status is anything else')
+    ->expect(fn() => new CallTransferResponse(status: Status::FAILED, errorMessage: 'InvalidPhoneNumber'))
+    ->isSuccessful()->toBeFalse();


### PR DESCRIPTION
## Summary

Implements Africa's Talking' [Call Transfer API](https://developers.africastalking.com/docs/voice/call_transfer), which moves an already-connected, two-legged call to a different number — distinct from the XML `dial()`/`redirect()` actions used when initially setting up a call.

```php
africastalking()->voice()
    ->transfer($sessionId)
    ->to('+254728900922')
    ->send();
```

- `Voice::transfer(?string $sessionId)` returns a new `CallTransfer` fluent builder (`to()`, `leg()`, `holdMusic()`, `send()`). `transferCall(?string $sessionId)` is kept as an alias for the same entry point.
- POSTs to `/callTransfer` on the Voice service (`CallTransferRequest`), form-encoded, matching how the rest of the SDK talks to Africa's Talking's Voice endpoints (confirmed against the reference implementation in Africa's Talking's Elixir SDK, since the official docs page is a JS-rendered SPA I couldn't scrape directly — same `sessionId`/`phoneNumber`/`callLeg`/`holdMusicUrl` params, same `/callTransfer` path on `voice(.sandbox).africastalking.com`).
- New `CallLeg` enum (`CALLER`/`CALLEE`) for the leg-selection param, set via `leg()`, accepting either the enum or its raw string value, matching the `Currency`/`Stash` convention elsewhere in the SDK. Defaults to `CallLeg::CALLEE` (Africa's Talking's own default) and is always sent explicitly rather than omitted.
- New `CallTransferResponse` DTO (`status: Status`, `errorMessage: string`, `isSuccessful(): bool`) — follows the `MobileCheckoutResponse`/`StashTopupResponse` convention of surfacing business-level failure via the response rather than throwing; only genuine HTTP-level failures throw (via Saloon's own `throw()`).

## Docs

Adds `docs/voice/call-transfer.md` (installation-free — no new dependencies needed for this feature) covering the API, getting `sessionId` from `VoiceEventRequest`, choosing a call leg, hold music, and a worked "transfer to a supervisor on DTMF" controller example — examples use `transfer()`, with `transferCall()` noted as an alias in the method reference table. Cross-linked from the existing "Forward Calls to an Agent" IVR example in `docs/voice/responses.md`, since that's the natural precursor (you `dial()` to connect a call, then later `transfer()` to move it).

## Changes since this PR was opened

- Addressed self-review feedback: `leg` (then `callLeg`) now defaults to `CallLeg::CALLEE` instead of being omitted when unset, and null-filtering moved from the Saloon request layer into `CallTransfer::data()` itself, matching `Message::data()`'s existing convention.
- Added `transfer()` as the preferred alias for `transferCall()`, and switched all docs examples to use it.
- Renamed `callLeg()` to `leg()` on the `CallTransfer` builder — the parameter is already `CallLeg`-typed, so the prefix was redundant.

## Test plan
- [x] `vendor/bin/pest` — full suite: 1828 passed (8015 assertions) covering: resolving the builder via both `transfer()`/`transferCall()`, a successful transfer via either name, sessionId/phoneNumber/username sent correctly with a default `callLeg` of `callee`, `holdMusicUrl` omitted when unset, `leg()` accepting both string and enum, `holdMusicUrl` included when set, an HTTP-level failure throwing, and full `CallTransferResponse` DTO coverage (`__toString`/`__toArray`/`make()`/`isSuccessful()` for both outcomes)
- [x] `vendor/bin/pint --test` — clean
- [x] `npm run build` in `docs/` — succeeds
- [x] `vendor/bin/phpstan analyse` — not runnable in this sandbox (see prior PRs); CI runs it and is green
- [x] Codecov — 100% patch coverage, project +0.15%

Companion PR adding fake/assert test helpers for call transfer to `samuelmwangiw/africastalking-laravel-tests`: [#5](https://github.com/SamuelMwangiW/africastalking-laravel-tests/pull/5) (currently blocked on this PR merging, since it depends on `dev-main` of this package).