### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -5,6 +5,9 @@ on:
     types: [released]
   workflow_call:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SamuelMwangiW/africastalking-laravel/security/code-scanning/4](https://github.com/SamuelMwangiW/africastalking-laravel/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so token scope is documented and constrained.  
Best fix without changing behavior: define workflow-level permissions with:

- `contents: write` (required to push updated `CHANGELOG.md` back to the branch)
- `pull-requests: read` is not required by shown steps, so omit.
- Keep scope minimal beyond what’s needed.

In `.github/workflows/update-changelog.yml`, insert the `permissions` block after the `on:` section (before `jobs:`), so it applies to all jobs unless overridden.