### PR TITLE
Add file size to CallRecordingDownloaded event

### DIFF
--- a/src/Events/CallRecordingDownloaded.php
+++ b/src/Events/CallRecordingDownloaded.php
@@ -18,5 +18,6 @@ class CallRecordingDownloaded
         public readonly string $recordingUrl,
         public readonly string $path,
         public readonly string $disk,
+        public readonly int $size,
     ) {}
 }

--- a/src/Jobs/DownloadCallRecording.php
+++ b/src/Jobs/DownloadCallRecording.php
@@ -52,7 +52,7 @@ class DownloadCallRecording implements ShouldBeUnique, ShouldQueue
             $this->disk(),
         )->put($path, $file);
 
-        CallRecordingDownloaded::dispatch($this->callSessionId, $this->url, $path, $this->disk());
+        CallRecordingDownloaded::dispatch($this->callSessionId, $this->url, $path, $this->disk(), mb_strlen($file, '8bit'));
     }
 
     public function uniqueId(): string

--- a/tests/Feature/Requests/VoiceEventRequestTest.php
+++ b/tests/Feature/Requests/VoiceEventRequestTest.php
@@ -117,7 +117,10 @@ it('can fail to downloads a recording to disk', function (string $url): void {
 it('dispatches an event after downloading a recording', function (string $url): void {
     Storage::fake();
     Event::fake([CallRecordingDownloaded::class]);
-    Http::fake();
+    $body = 'a fake recording body';
+    Http::fake([
+        '*' => Http::response($body),
+    ]);
 
     Storage::deleteDirectory('call-recordings');
 
@@ -127,7 +130,9 @@ it('dispatches an event after downloading a recording', function (string $url): 
         event: CallRecordingDownloaded::class,
         callback: fn(
             CallRecordingDownloaded $event,
-        ) => $event->recordingUrl === $url && 'sessionId' === $event->sessionId,
+        ) => $event->recordingUrl === $url
+            && 'sessionId' === $event->sessionId
+            && mb_strlen($body, '8bit') === $event->size,
     );
 })->with([
     'https://example.com/Free_Test_Data_100KB_MP3.mp3',


### PR DESCRIPTION
## Summary

- Adds a `size: int` property to `CallRecordingDownloaded`, giving listeners the downloaded recording's byte size without needing to stat the file themselves.
- `DownloadCallRecording::handle()` computes the size from the already-downloaded response body (`$file`, already in memory) and passes it when dispatching the event — no extra I/O or storage round-trip needed.
- Uses `mb_strlen($file, '8bit')` rather than plain `strlen()`, since this repo's `pint.json` has a blanket `mb_str_functions` rule that auto-fixes `strlen()` → `mb_strlen()`. Plain `mb_strlen()` would be **wrong** here — it counts multi-byte characters assuming UTF-8, which misrepresents binary audio content. Passing the `'8bit'` encoding makes `mb_strlen()` count raw bytes (one "character" per byte), giving the same correct result as `strlen()` while satisfying the lint rule.

## Test plan
- [x] `vendor/bin/pest` — full suite: 1828 passed (8015 assertions). Updated the existing "dispatches an event after downloading a recording" test to fake a response body with known content and assert `$event->size` matches its exact byte length.
- [x] `vendor/bin/pint --test` — clean
- [x] `vendor/bin/phpstan analyse` — not runnable in this sandbox (see prior PRs); CI will run it

---
_Generated by [Claude Code](https://claude.ai/code/session_017QX6mcz1R7MrvZF2bT9FY2)_